### PR TITLE
add support for webp when parse image

### DIFF
--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -73,6 +73,7 @@ function parseImage(image: md.Image, options: BlocksOptions): notion.Block {
     '.bmp',
     '.svg',
     '.heic',
+    '.webp',
   ];
 
   function dealWithError() {


### PR DESCRIPTION
Many thanks for the excellent package!

When I use this package to parse images, the `webp` URL cannot be recognised as a valid URL. 

