### PR TITLE
feat: add support for thematic breaks/dividers in markdown parsing

### DIFF
--- a/src/notion/blocks.ts
+++ b/src/notion/blocks.ts
@@ -12,6 +12,14 @@ export type RichText = (Block & {
   type: 'paragraph';
 })['paragraph']['rich_text'][number];
 
+export function divider(): Block {
+  return {
+    object: 'block',
+    type: 'divider',
+    divider: {},
+  };
+}
+
 export function paragraph(text: RichText[]): Block {
   return {
     object: 'block',

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -241,6 +241,9 @@ function parseNode(
     case 'math':
       return [parseMath(node)];
 
+    case 'thematicBreak':
+      return [notion.divider()];
+
     default:
       return [];
   }

--- a/test/fixtures/divider.md
+++ b/test/fixtures/divider.md
@@ -1,0 +1,9 @@
+Thematic Break
+
+***
+
+Divider
+
+---
+
+END

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -92,6 +92,21 @@ const hello = "hello";
 
       expect(actual).toStrictEqual(expected);
     });
+    
+    it('should deal with divider', () => {
+      const text = fs.readFileSync('test/fixtures/divider.md').toString();
+      const actual = markdownToBlocks(text);
+
+      const expected = [
+        notion.paragraph([notion.richText('Thematic Break')]),
+        notion.divider(),
+        notion.paragraph([notion.richText('Divider')]),
+        notion.divider(),
+        notion.paragraph([notion.richText('END')]),
+      ];
+
+      expect(actual).toStrictEqual(expected);
+    });
 
     it('should break up large elements', () => {
       const text = fs.readFileSync('test/fixtures/large-item.md').toString();

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -19,6 +19,7 @@ hello _world_
           notion.richText('hello '),
           notion.richText('world', {annotations: {italic: true}}),
         ]),
+        notion.divider(),
         notion.headingTwo([notion.richText('heading2')]),
         notion.toDo(true, [notion.richText('todo')]),
       ];
@@ -92,7 +93,7 @@ const hello = "hello";
 
       expect(actual).toStrictEqual(expected);
     });
-    
+
     it('should deal with divider', () => {
       const text = fs.readFileSync('test/fixtures/divider.md').toString();
       const actual = markdownToBlocks(text);

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -79,6 +79,7 @@ describe('gfm parser', () => {
 
     const expected = [
       notion.paragraph([notion.richText('hello')]),
+      notion.divider(),
       notion.paragraph([notion.richText('world')]),
     ];
 


### PR DESCRIPTION
This commit adds support for thematic breaks/dividers in the markdown parsing functionality. It introduces a new function `divider()` in the `blocks.ts` file, which creates a divider block. Additionally, the `parseNode()` function in the `internal.ts` file has been updated to handle the `thematicBreak` node type and convert it into a divider block.