### PR TITLE
refactor: Remove annotations from code block rich text

### DIFF
--- a/src/notion/common.ts
+++ b/src/notion/common.ts
@@ -25,6 +25,7 @@ export interface RichTextOptions {
     color?: string;
   };
   url?: string;
+  omitAnnotations?: boolean;
 }
 
 function isValidURL(url: string | undefined): boolean {
@@ -40,20 +41,22 @@ export function richText(
   content: string,
   options: RichTextOptions = {}
 ): RichText {
-  const annotations: RichText['annotations'] = {
-    bold: false,
-    strikethrough: false,
-    underline: false,
-    italic: false,
-    code: false,
-    color: 'default' as const,
-    ...((options.annotations as RichText['annotations']) || {}),
-  };
+  const annotations = options.omitAnnotations
+    ? undefined
+    : {
+        bold: false,
+        strikethrough: false,
+        underline: false,
+        italic: false,
+        code: false,
+        color: 'default' as const,
+        ...((options.annotations as RichText['annotations']) || {}),
+      };
 
   if (options.type === 'equation')
     return {
       type: 'equation',
-      annotations,
+      ...(annotations && {annotations}),
       equation: {
         expression: content,
       },
@@ -61,7 +64,7 @@ export function richText(
   else
     return {
       type: 'text',
-      annotations,
+      ...(annotations && {annotations}),
       text: {
         content: content,
         link: isValidURL(options.url)

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -161,17 +161,7 @@ function parseHeading(element: md.Heading): notion.Block {
 }
 
 function parseCode(element: md.Code): notion.Block {
-  // Create rich text without annotations field for code blocks
-  const text =
-    element.value.match(/[^]{1,2000}/g)?.map(
-      chunk =>
-        ({
-          type: 'text',
-          text: {
-            content: chunk,
-          },
-        } as notion.RichText)
-    ) || [];
+  const text = ensureLength(element.value, {omitAnnotations: true});
   const lang = ensureCodeBlockLanguage(element.lang);
   return notion.code(text, lang);
 }

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -161,7 +161,17 @@ function parseHeading(element: md.Heading): notion.Block {
 }
 
 function parseCode(element: md.Code): notion.Block {
-  const text = ensureLength(element.value);
+  // Create rich text without annotations field for code blocks
+  const text =
+    element.value.match(/[^]{1,2000}/g)?.map(
+      chunk =>
+        ({
+          type: 'text',
+          text: {
+            content: chunk,
+          },
+        } as notion.RichText)
+    ) || [];
   const lang = ensureCodeBlockLanguage(element.lang);
   return notion.code(text, lang);
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -39,14 +39,7 @@ const hello = "hello";
       const expected = [
         notion.headingTwo([notion.richText('Code')]),
         notion.code(
-          [
-            {
-              type: 'text',
-              text: {
-                content: 'const hello = "hello";',
-              },
-            } as notion.RichText,
-          ],
+          [notion.richText('const hello = "hello";', {omitAnnotations: true})],
           'plain text'
         ),
       ];
@@ -66,14 +59,7 @@ const hello = "hello";
       const expected = [
         notion.headingTwo([notion.richText('Code')]),
         notion.code(
-          [
-            {
-              type: 'text',
-              text: {
-                content: 'const hello = "hello";',
-              },
-            } as notion.RichText,
-          ],
+          [notion.richText('const hello = "hello";', {omitAnnotations: true})],
           'webassembly'
         ),
       ];
@@ -93,14 +79,7 @@ const hello = "hello";
       const expected = [
         notion.headingTwo([notion.richText('Code')]),
         notion.code(
-          [
-            {
-              type: 'text',
-              text: {
-                content: 'const hello = "hello";',
-              },
-            } as notion.RichText,
-          ],
+          [notion.richText('const hello = "hello";', {omitAnnotations: true})],
           'typescript'
         ),
       ];

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -38,7 +38,17 @@ const hello = "hello";
 
       const expected = [
         notion.headingTwo([notion.richText('Code')]),
-        notion.code([notion.richText('const hello = "hello";')], 'plain text'),
+        notion.code(
+          [
+            {
+              type: 'text',
+              text: {
+                content: 'const hello = "hello";',
+              },
+            } as notion.RichText,
+          ],
+          'plain text'
+        ),
       ];
 
       expect(actual).toStrictEqual(expected);
@@ -55,7 +65,17 @@ const hello = "hello";
 
       const expected = [
         notion.headingTwo([notion.richText('Code')]),
-        notion.code([notion.richText('const hello = "hello";')], 'webassembly'),
+        notion.code(
+          [
+            {
+              type: 'text',
+              text: {
+                content: 'const hello = "hello";',
+              },
+            } as notion.RichText,
+          ],
+          'webassembly'
+        ),
       ];
 
       expect(actual).toStrictEqual(expected);
@@ -72,7 +92,17 @@ const hello = "hello";
 
       const expected = [
         notion.headingTwo([notion.richText('Code')]),
-        notion.code([notion.richText('const hello = "hello";')], 'typescript'),
+        notion.code(
+          [
+            {
+              type: 'text',
+              text: {
+                content: 'const hello = "hello";',
+              },
+            } as notion.RichText,
+          ],
+          'typescript'
+        ),
       ];
 
       expect(actual).toStrictEqual(expected);

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -117,14 +117,7 @@ describe('gfm parser', () => {
     const expected = [
       notion.paragraph([notion.richText('hello')]),
       notion.code(
-        [
-          {
-            type: 'text',
-            text: {
-              content: 'const foo = () => {}',
-            },
-          } as notion.RichText,
-        ],
+        [notion.richText('const foo = () => {}', {omitAnnotations: true})],
         'plain text'
       ),
     ];
@@ -142,14 +135,7 @@ describe('gfm parser', () => {
     const expected = [
       notion.paragraph([notion.richText('hello')]),
       notion.code(
-        [
-          {
-            type: 'text',
-            text: {
-              content: 'public class Foo {}',
-            },
-          } as notion.RichText,
-        ],
+        [notion.richText('public class Foo {}', {omitAnnotations: true})],
         'java'
       ),
     ];
@@ -168,14 +154,7 @@ describe('gfm parser', () => {
     const expected = [
       notion.paragraph([notion.richText('hello')]),
       notion.code(
-        [
-          {
-            type: 'text',
-            text: {
-              content: 'const foo = () => {}',
-            },
-          } as notion.RichText,
-        ],
+        [notion.richText('const foo = () => {}', {omitAnnotations: true})],
         'plain text'
       ),
     ];
@@ -190,14 +169,7 @@ describe('gfm parser', () => {
 
     const expected = [
       notion.code(
-        [
-          {
-            type: 'text',
-            text: {
-              content: 'const foo = "bar";',
-            },
-          } as notion.RichText,
-        ],
+        [notion.richText('const foo = "bar";', {omitAnnotations: true})],
         'typescript'
       ),
     ];

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -162,21 +162,6 @@ describe('gfm parser', () => {
     expect(actual).toStrictEqual(expected);
   });
 
-  it('should parse code block with rich text without annotations field', () => {
-    const ast = md.root(md.code('const foo = "bar";', 'typescript'));
-
-    const actual = parseBlocks(ast, options);
-
-    const expected = [
-      notion.code(
-        [notion.richText('const foo = "bar";', {omitAnnotations: true})],
-        'typescript'
-      ),
-    ];
-
-    expect(actual).toStrictEqual(expected);
-  });
-
   it('should parse block quote', () => {
     const ast = md.root(
       md.blockquote(

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -116,7 +116,17 @@ describe('gfm parser', () => {
 
     const expected = [
       notion.paragraph([notion.richText('hello')]),
-      notion.code([notion.richText('const foo = () => {}')], 'plain text'),
+      notion.code(
+        [
+          {
+            type: 'text',
+            text: {
+              content: 'const foo = () => {}',
+            },
+          } as notion.RichText,
+        ],
+        'plain text'
+      ),
     ];
     expect(actual).toStrictEqual(expected);
   });
@@ -131,7 +141,17 @@ describe('gfm parser', () => {
 
     const expected = [
       notion.paragraph([notion.richText('hello')]),
-      notion.code([notion.richText('public class Foo {}')], 'java'),
+      notion.code(
+        [
+          {
+            type: 'text',
+            text: {
+              content: 'public class Foo {}',
+            },
+          } as notion.RichText,
+        ],
+        'java'
+      ),
     ];
 
     expect(actual).toStrictEqual(expected);
@@ -147,7 +167,39 @@ describe('gfm parser', () => {
 
     const expected = [
       notion.paragraph([notion.richText('hello')]),
-      notion.code([notion.richText('const foo = () => {}')], 'plain text'),
+      notion.code(
+        [
+          {
+            type: 'text',
+            text: {
+              content: 'const foo = () => {}',
+            },
+          } as notion.RichText,
+        ],
+        'plain text'
+      ),
+    ];
+
+    expect(actual).toStrictEqual(expected);
+  });
+
+  it('should parse code block with rich text without annotations field', () => {
+    const ast = md.root(md.code('const foo = "bar";', 'typescript'));
+
+    const actual = parseBlocks(ast, options);
+
+    const expected = [
+      notion.code(
+        [
+          {
+            type: 'text',
+            text: {
+              content: 'const foo = "bar";',
+            },
+          } as notion.RichText,
+        ],
+        'typescript'
+      ),
     ];
 
     expect(actual).toStrictEqual(expected);


### PR DESCRIPTION
Investigation into Notion Code Block Syntax Highlighting

While investigating code block syntax highlighting issues, I discovered that Notion's frontend disables syntax highlighting when the `annotations` field is present in code block rich text objects - even with default values. This appears to be an undocumented behavior in Notion's frontend rendering, as:

1. The Notion API documentation explicitly specifies including annotations
2. Blocks retrieved via API include annotations regardless of how they were created
3. The same block structure renders differently based on whether annotations were present during creation

## Current PR
This PR removes annotations from code blocks to work around the Notion frontend issue. However, I'm having second thoughts about this approach:

### Pros
+ Improves syntax highlighting out of the box
+ Reduces confusion for users experiencing the issue

### Cons
- Deviates from Notion API documentation
- May need reverting if Notion fixes their frontend
- Places workaround in wrong layer - this should be handled in Notion sync scripts

## Alternative Approach
A better solution might be to:
1. Keep martian aligned with Notion's API documentation
2. Document this Notion frontend behavior
3. Let users handle annotation filtering in their sync scripts if needed