### PR TITLE
Update @notionhq/client to v2.2.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.4",
       "license": "ISC",
       "dependencies": {
-        "@notionhq/client": "^1.0.4",
+        "@notionhq/client": "^2.2.15",
         "remark-gfm": "^1.0.0",
         "remark-math": "^4.0.0",
         "remark-parse": "^9.0.0",
@@ -1070,9 +1070,10 @@
       }
     },
     "node_modules/@notionhq/client": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
-      "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.15.tgz",
+      "integrity": "sha512-XhdSY/4B1D34tSco/GION+23GMjaS9S2zszcqYkMHo8RcWInymF6L1x+Gk7EmHdrSxNFva2WM8orhC4BwQCwgw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1"
@@ -7119,9 +7120,9 @@
       }
     },
     "@notionhq/client": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-1.0.4.tgz",
-      "integrity": "sha512-m7zZ5l3RUktayf1lRBV1XMb8HSKsmWTv/LZPqP7UGC1NMzOlc+bbTOPNQ4CP/c1P4cP61VWLb/zBq7a3c0nMaw==",
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-2.2.15.tgz",
+      "integrity": "sha512-XhdSY/4B1D34tSco/GION+23GMjaS9S2zszcqYkMHo8RcWInymF6L1x+Gk7EmHdrSxNFva2WM8orhC4BwQCwgw==",
       "requires": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Richard Robinson",
   "license": "ISC",
   "dependencies": {
-    "@notionhq/client": "^1.0.4",
+    "@notionhq/client": "^2.2.15",
     "remark-gfm": "^1.0.0",
     "remark-math": "^4.0.0",
     "remark-parse": "^9.0.0",

--- a/src/notion/blocks.ts
+++ b/src/notion/blocks.ts
@@ -1,4 +1,4 @@
-import {richText, supportedCodeLang} from './common';
+import {richText, supportedCodeLang, TableRowBlock} from './common';
 import {AppendBlockChildrenParameters} from '@notionhq/client/build/src/api-endpoints';
 
 export type Block = AppendBlockChildrenParameters['children'][number];
@@ -155,10 +155,7 @@ export function toDo(
   };
 }
 
-export function table(
-  children: BlockWithoutChildren[],
-  tableWidth: number
-): Block {
+export function table(children: TableRowBlock[], tableWidth: number): Block {
   return {
     object: 'block',
     type: 'table',
@@ -170,7 +167,7 @@ export function table(
   };
 }
 
-export function tableRow(cells: RichText[][] = []): BlockWithoutChildren {
+export function tableRow(cells: RichText[][] = []): TableRowBlock {
   return {
     object: 'block',
     type: 'table_row',

--- a/src/notion/common.ts
+++ b/src/notion/common.ts
@@ -154,3 +154,11 @@ export type supportedCodeLang = typeof SUPPORTED_CODE_BLOCK_LANGUAGES[number];
 export function isSupportedCodeLang(lang: string): lang is supportedCodeLang {
   return (SUPPORTED_CODE_BLOCK_LANGUAGES as readonly string[]).includes(lang);
 }
+
+export interface TableRowBlock {
+  type: 'table_row';
+  table_row: {
+    cells: Array<Array<RichText>>;
+  };
+  object?: 'block';
+}

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -191,13 +191,13 @@ function parseList(element: md.List, options: BlocksOptions): notion.Block[] {
   });
 }
 
-function parseTableCell(node: md.TableCell): notion.RichText[][] {
-  return [node.children.flatMap(child => parseInline(child))];
+function parseTableCell(node: md.TableCell): notion.RichText[] {
+  return node.children.flatMap(child => parseInline(child));
 }
 
-function parseTableRow(node: md.TableRow): notion.BlockWithoutChildren[] {
-  const tableCells = node.children.flatMap(child => parseTableCell(child));
-  return [notion.tableRow(tableCells)];
+function parseTableRow(node: md.TableRow): notion.TableRowBlock {
+  const cells = node.children.map(child => parseTableCell(child));
+  return notion.tableRow(cells);
 }
 
 function parseTable(node: md.Table): notion.Block[] {
@@ -206,7 +206,7 @@ function parseTable(node: md.Table): notion.Block[] {
     ? node.children[0].children.length
     : 0;
 
-  const tableRows = node.children.flatMap(child => parseTableRow(child));
+  const tableRows = node.children.map(child => parseTableRow(child));
   return [notion.table(tableRows, tableWidth)];
 }
 


### PR DESCRIPTION
**Description**:
- Bump `@notionhq/client` from `^1.0.4` to `^2.2.15` in `package.json`.
- Update corresponding `package-lock.json`.
- Adjust `table` and `tableRow` definitions to match new Notion typings.
- Resolve breaking changes in `src/notion/blocks.ts`, `src/notion/common.ts`, and `src/parser/internal.ts`.

**Context**:
- Fixes type errors caused by the older Notion client.
- Incorporates new features/fixes from Notion’s v2.x.x releases (table blocks, updated field definitions, etc.).
- Breaking changes were introduced in v2.0.0, see release notes [here](https://github.com/makenotion/notion-sdk-js/releases/tag/v2.0.0) for additional details.

**Testing**:
- [x] All tests passing locally.
- [x] Verified table rendering logic against the updated Notion API.
- [x] No regressions identified in existing functionality.