### PR TITLE
Support hard line breaks to start a new paragraph

### DIFF
--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -118,23 +118,34 @@ function parseParagraph(
   // Notion doesn't deal with inline images, so we need to parse them all out
   // of the paragraph into individual blocks
   const images: notion.Block[] = [];
-  const paragraphs: Array<notion.RichText[]> = [];
+  const paragraphs: notion.RichText[][] = [];
+  let currentParagraph: notion.RichText[] = [];
+
+  const pushParagraph = () => {
+    if (currentParagraph.length > 0) {
+      paragraphs.push(currentParagraph);
+      currentParagraph = [];
+    }
+  };
+
   element.children.forEach(item => {
     if (item.type === 'image') {
       images.push(parseImage(item, options));
-    } else {
-      const richText = parseInline(item) as notion.RichText[];
-      if (richText.length) {
-        paragraphs.push(richText);
-      }
+      return;
     }
+
+    if (item.type === 'break') {
+      pushParagraph();
+      return;
+    }
+
+    const richText = parseInline(item) as notion.RichText[];
+    currentParagraph.push(...richText);
   });
 
-  if (paragraphs.length) {
-    return [...paragraphs.map(notion.paragraph), ...images];
-  } else {
-    return images;
-  }
+  pushParagraph();
+
+  return [...paragraphs.map(notion.paragraph), ...images];
 }
 
 function parseBlockquote(

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -218,6 +218,30 @@ const hello = "hello";
 
       expect(actual).toStrictEqual(expected);
     });
+
+    it('should split paragraphs on hard line breaks', () => {
+      const text =
+        'You can _italicize_ or **bold** text.  \nThis is the second line of text.\nAnd this is in the same line';
+
+      const actual = markdownToBlocks(text);
+
+      const expected = [
+        notion.paragraph([
+          notion.richText('You can '),
+          notion.richText('italicize', {annotations: {italic: true}}),
+          notion.richText(' or '),
+          notion.richText('bold', {annotations: {bold: true}}),
+          notion.richText(' text.'),
+        ]),
+        notion.paragraph([
+          notion.richText(
+            'This is the second line of text.\nAnd this is in the same line',
+          ),
+        ]),
+      ];
+
+      expect(actual).toStrictEqual(expected);
+    });
   });
 
   describe('markdownToRichText', () => {

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -271,6 +271,39 @@ describe('gfm parser', () => {
     expect(actual).toStrictEqual(expected);
   });
 
+  it('should split paragraphs on hard line breaks', () => {
+    // Simulate markdown where a line ends with two spaces followed by \n, which renders as a hard line break.
+    // In the mdast AST this is represented as a `break` node within the paragraph.
+    const br: md.Break = {type: 'break'} as md.Break;
+
+    const ast = md.root(
+      md.paragraph(
+        md.text('You can '),
+        md.emphasis(md.text('italicize')),
+        md.text(' or '),
+        md.strong(md.text('bold')),
+        md.text(' text.'),
+        br,
+        md.text('This is the second line of text'),
+      ),
+    );
+
+    const actual = parseBlocks(ast, options);
+
+    const expected = [
+      notion.paragraph([
+        notion.richText('You can '),
+        notion.richText('italicize', {annotations: {italic: true}}),
+        notion.richText(' or '),
+        notion.richText('bold', {annotations: {bold: true}}),
+        notion.richText(' text.'),
+      ]),
+      notion.paragraph([notion.richText('This is the second line of text')]),
+    ];
+
+    expect(actual).toStrictEqual(expected);
+  });
+
   it('should parse github extensions', () => {
     const ast = md.root(
       md.paragraph(


### PR DESCRIPTION
Adds support to break up text content that contains 2 spaces followed by \n into separate paragraphs.
Should fix #49 


Using this **input**:
```
You can _italicize_ or **bold** text.  \nThis is the second line of text.\nAnd this is in the same line
```

**Before**:
<img width="732" alt="image" src="https://github.com/user-attachments/assets/dad9fb01-1fe1-4a03-9c3a-1ed30350ee25" />


**After**:
<img width="734" alt="image" src="https://github.com/user-attachments/assets/f9760d97-18b6-49c9-8348-751ca8cea18a" />

